### PR TITLE
export PID class

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ You can customize the behavior of specific renderers by passing a JSON configura
 ></pid-component>
 ```
 
+## PID Resolver
+
+The `pid-component` package exports a useful helper class for resolving PIDs. These are `PID`, `PIDDataType` and `PIDRecord` and can be
+imported like this:
+
+```typescript
+import { PID, PIDDataType, PIDRecord } from "@kit-data-manager/pid-component"
+
+const pid = new PID("21.T11981/be908bd1-e049-4d35-975e-8e27d40117e6")
+const pidRecord = await pid.resolve()
+const pidDataType = await PIDDataType.resolveDataType(pid)
+```
+
+Further documentation is available in the [source code](packages/stencil-library/src/rendererModules/Handle/PID.ts).
+
 ## Monorepo
 
 This is a monorepo containing the following packages:

--- a/packages/stencil-library/src/index.ts
+++ b/packages/stencil-library/src/index.ts
@@ -1,2 +1,4 @@
 export * from './components';
 export { PID } from './rendererModules/Handle/PID'
+export { PIDDataType } from './rendererModules/Handle/PIDDataType'
+export { PIDRecord } from './rendererModules/Handle/PIDRecord'

--- a/packages/stencil-library/src/index.ts
+++ b/packages/stencil-library/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export { PID } from './rendererModules/Handle/PID'


### PR DESCRIPTION
The PID class provides a very useful interface for resolving PIDs. Since I needed this functionality multiple times in different situations, it would be best to directly export it from the component than to copy the underlying code