### PR TITLE
FAIR DO MoMEnT simple type system support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -981,9 +981,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,9 +999,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1023,9 +1017,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1044,9 +1035,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4330,9 +4318,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4348,9 +4333,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -4368,9 +4350,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4386,9 +4365,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -4406,9 +4382,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4424,9 +4397,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -4444,9 +4414,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4463,9 +4430,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4481,9 +4445,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4507,9 +4468,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4531,9 +4489,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4557,9 +4512,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4581,9 +4533,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4607,9 +4556,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4632,9 +4578,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4656,9 +4599,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6224,9 +6164,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6245,9 +6182,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6266,9 +6200,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6287,9 +6218,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6308,9 +6236,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6329,9 +6254,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6350,9 +6272,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6499,9 +6418,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6517,9 +6433,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6537,9 +6450,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6555,9 +6465,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7149,9 +7056,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7166,9 +7070,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7183,9 +7084,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7200,9 +7098,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7704,9 +7599,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7724,9 +7616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7744,9 +7633,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7764,9 +7650,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7784,9 +7667,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7804,9 +7684,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7824,9 +7701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7844,9 +7718,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8123,9 +7994,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8140,9 +8008,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8157,9 +8022,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8174,9 +8036,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8191,9 +8050,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8208,9 +8064,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8225,9 +8078,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8242,9 +8092,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8504,9 +8351,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8527,9 +8371,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8552,9 +8393,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8575,9 +8413,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8600,9 +8435,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8623,9 +8455,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9636,9 +9465,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9654,9 +9480,6 @@
       "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9674,9 +9497,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9692,9 +9512,6 @@
       "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -9712,9 +9529,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9730,9 +9544,6 @@
       "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9992,9 +9803,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10010,9 +9818,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10027,9 +9832,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10042,9 +9844,6 @@
       "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10060,9 +9859,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10078,9 +9874,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10096,9 +9889,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10114,9 +9904,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10132,9 +9919,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10150,9 +9934,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10168,9 +9949,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10185,9 +9963,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10200,9 +9975,6 @@
       "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11430,9 +11202,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11448,9 +11217,6 @@
       "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11468,9 +11234,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11486,9 +11249,6 @@
       "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -20005,9 +19765,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -20027,9 +19784,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -20051,9 +19805,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -20073,9 +19824,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -25537,9 +25285,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25555,9 +25300,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25573,9 +25315,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25591,9 +25330,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30019,9 +29755,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30039,9 +29772,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30059,9 +29789,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30079,9 +29806,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30099,9 +29823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30119,9 +29840,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30535,9 +30253,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30555,9 +30270,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30575,9 +30287,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30595,9 +30304,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30615,9 +30321,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -30635,9 +30338,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31069,9 +30769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31089,9 +30786,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31109,9 +30803,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31129,9 +30820,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31149,9 +30837,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31169,9 +30854,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31584,9 +31266,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31604,9 +31283,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31624,9 +31300,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31644,9 +31317,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31664,9 +31334,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -31684,9 +31351,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pid-component",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pid-component",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -29736,13 +29736,13 @@
     },
     "packages/angular-library": {
       "name": "@kit-data-manager/angular-pid-component",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/cdk": "^21.2.11",
         "@angular/forms": "^21.2.13",
         "@angular/material": "^21.2.11",
-        "@kit-data-manager/pid-component": "^0.4.2",
+        "@kit-data-manager/pid-component": "^0.4.3",
         "@stencil/angular-output-target": "^1.3.1"
       },
       "devDependencies": {
@@ -29832,10 +29832,10 @@
     },
     "packages/nextjs-app": {
       "name": "@kit-data-manager/nextjs-pid-component-demo",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@kit-data-manager/pid-component": "^0.4.2",
-        "@kit-data-manager/react-pid-component": "^0.4.2",
+        "@kit-data-manager/pid-component": "^0.4.3",
+        "@kit-data-manager/react-pid-component": "^0.4.3",
         "@tailwindcss/postcss": "^4.3.0",
         "next": "^16.2.6",
         "react": "^19.2.6",
@@ -30354,10 +30354,10 @@
     },
     "packages/react-library": {
       "name": "@kit-data-manager/react-pid-component",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kit-data-manager/pid-component": "^0.4.2",
+        "@kit-data-manager/pid-component": "^0.4.3",
         "@stencil/react-output-target": "^1.5.2"
       },
       "devDependencies": {
@@ -30870,7 +30870,7 @@
     },
     "packages/stencil-library": {
       "name": "@kit-data-manager/pid-component",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@stencil/core": "^4.43.4",
@@ -31404,10 +31404,10 @@
     },
     "packages/vue-library": {
       "name": "@kit-data-manager/vue-pid-component",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kit-data-manager/pid-component": "^0.4.2",
+        "@kit-data-manager/pid-component": "^0.4.3",
         "@stencil/vue-output-target": "^0.13.1"
       },
       "devDependencies": {

--- a/packages/stencil-library/src/rendererModules/Handle/PID.ts
+++ b/packages/stencil-library/src/rendererModules/Handle/PID.ts
@@ -103,7 +103,7 @@ export class PID {
    * @returns {boolean} True if the PID is resolvable, false if not.
    */
   isResolvable(): boolean {
-    return !unresolvables.has(this) && !this.prefix.toUpperCase().match('^(0$|0\\.|HS_|10320$)');
+    return !unresolvables.has(this) && !this.prefix.toUpperCase().match('^(0$|0\\.(?!SIMPLE)|HS_|10320$)');
   }
 
   /**
@@ -115,7 +115,10 @@ export class PID {
   public async resolve(): Promise<PIDRecord | undefined> {
     if (unresolvables.has(this)) return undefined;
     else if (handleMap.has(this)) return handleMap.get(this);
-    else {
+    /*else if(this.prefix.toUpperCase().match('^0\\.SIMPLE')){
+      //load 0.SIMPLE types from FAIR DO MoMEnT specific GitHub DTR
+    }*/
+    else{
       const rawJson: HandleResponse = (await cachedFetch(`https://hdl.handle.net/api/handles/${this.prefix}/${this.suffix}#resolve`)) as HandleResponse;
       // .then(response => response.json);
       console.log(rawJson);

--- a/packages/stencil-library/src/rendererModules/Handle/PID.ts
+++ b/packages/stencil-library/src/rendererModules/Handle/PID.ts
@@ -1,5 +1,6 @@
 import { PIDRecord } from './PIDRecord';
 import { PIDDataType } from './PIDDataType';
+import { GitHubRegistryUtil } from '../../utils/GitHubRegistryUtil';
 import { handleMap, unresolvables } from '../../utils/utils';
 import { cachedFetch } from '../../utils/DataCache';
 
@@ -103,7 +104,7 @@ export class PID {
    * @returns {boolean} True if the PID is resolvable, false if not.
    */
   isResolvable(): boolean {
-    return !unresolvables.has(this) && !this.prefix.toUpperCase().match('^(0$|0\\.(?!SIMPLE)|HS_|10320$)');
+    return !unresolvables.has(this.toString()) && !this.prefix.toUpperCase().match('^(0$|0\\.(?!SIMPLE)|HS_|10320$)');
   }
 
   /**
@@ -113,38 +114,47 @@ export class PID {
    * Otherwise, undefined is returned.
    */
   public async resolve(): Promise<PIDRecord | undefined> {
-    if (unresolvables.has(this)) return undefined;
-    else if (handleMap.has(this)) return handleMap.get(this);
-    /*else if(this.prefix.toUpperCase().match('^0\\.SIMPLE')){
-      //load 0.SIMPLE types from FAIR DO MoMEnT specific GitHub DTR
-    }*/
-    else{
-      const rawJson: HandleResponse = (await cachedFetch(`https://hdl.handle.net/api/handles/${this.prefix}/${this.suffix}#resolve`)) as HandleResponse;
-      // .then(response => response.json);
-      console.log(rawJson);
-      const valuePromises = rawJson.values.map(async value => {
-        const type: Promise<PIDDataType | PID | string> = (async () => {
-          if (PID.isPID(value.type)) {
-            const pid = PID.getPIDFromString(value.type);
-            const dataType = await PIDDataType.resolveDataType(pid);
-            return dataType instanceof PIDDataType ? dataType : pid;
-          }
-          return value.type;
-        })();
-        return {
-          index: value.index,
-          type: await type,
-          data: value.data,
-          ttl: value.ttl,
-          timestamp: Date.parse(value.timestamp),
-        };
-      });
-      const values = await Promise.all(valuePromises);
-
-      const record = new PIDRecord(this, values);
-      handleMap.set(this, record);
-      return record;
+    if (unresolvables.has(this.toString())) {
+      console.log("Cannot be resolved.");
+      return undefined;
     }
+    else if (handleMap.has(this.toString())){
+      console.log("Return from handleMap for PID ", this);
+      return handleMap.get(this.toString());
+    }
+    else if(this.prefix.toUpperCase().match('^0\\.SIMPLE')){
+      await GitHubRegistryUtil.initializeFromGitHub();
+      if (handleMap.has(this.toString())) {
+        console.log("Return from handleMap for PID ", this);
+        return handleMap.get(this.toString());
+      }
+      console.log(`0.SIMPLE PID ${this} not found in GitHub registry`);
+      return undefined;
+    }
+    const rawJson: HandleResponse = (await cachedFetch(`https://hdl.handle.net/api/handles/${this.prefix}/${this.suffix}#resolve`)) as HandleResponse;
+    console.log(rawJson);
+    const valuePromises = rawJson.values.map(async value => {
+      const type: Promise<PIDDataType | PID | string> = (async () => {
+        if (PID.isPID(value.type)) {
+          const pid = PID.getPIDFromString(value.type);
+          const dataType = await PIDDataType.resolveDataType(pid);
+          return dataType instanceof PIDDataType ? dataType : pid;
+        }
+        return value.type;
+      })();
+      return {
+        index: value.index,
+        type: await type,
+        data: value.data,
+        ttl: value.ttl,
+        timestamp: Date.parse(value.timestamp),
+      };
+    });
+    const values = await Promise.all(valuePromises);
+
+    const record = new PIDRecord(this, values);
+    handleMap.set(this.toString(), record);
+    return record;
   }
 
   toObject() {

--- a/packages/stencil-library/src/rendererModules/Handle/PIDDataType.ts
+++ b/packages/stencil-library/src/rendererModules/Handle/PIDDataType.ts
@@ -1,6 +1,7 @@
 import { locationType, PID } from './PID';
 import { typeMap, unresolvables } from '../../utils/utils';
 import { cachedFetch } from '../../utils/DataCache';
+import {GitHubRegistryUtil} from "../../utils/GitHubRegistryUtil";
 
 /**
  * This class represents a PID data type.
@@ -104,6 +105,10 @@ export class PIDDataType {
    * @param pid
    */
   public static async resolveDataType(pid: PID): Promise<PIDDataType | undefined> {
+
+    //Initialize GitHub-based DTR for FAIR DO MoMEnT at the first call
+    await GitHubRegistryUtil.initializeFromGitHub();
+
     // Check if PID is already resolved
     if (typeMap.has(pid)) return typeMap.get(pid);
 

--- a/packages/stencil-library/src/rendererModules/Handle/PIDDataType.ts
+++ b/packages/stencil-library/src/rendererModules/Handle/PIDDataType.ts
@@ -110,7 +110,7 @@ export class PIDDataType {
     await GitHubRegistryUtil.initializeFromGitHub();
 
     // Check if PID is already resolved
-    if (typeMap.has(pid)) return typeMap.get(pid);
+    if (typeMap.has(pid.toString())) return typeMap.get(pid.toString());
 
     // Check if PID is resolvable
     if (!pid.isResolvable()) {
@@ -122,7 +122,7 @@ export class PIDDataType {
     const pidRecord = await pid.resolve();
     if (pidRecord === undefined) {
       console.debug(`PID ${pid.toString()} could not be resolved via the API`);
-      unresolvables.add(pid);
+      unresolvables.add(pid.toString());
       return undefined;
     }
 
@@ -192,7 +192,7 @@ export class PIDDataType {
     // Create a new PIDDataType object from the temp object
     try {
       const type = new PIDDataType(pid, tempDataType.name, tempDataType.description, tempDataType.redirectURL, tempDataType.regex);
-      typeMap.set(pid, type);
+      typeMap.set(pid.toString(), type);
       return type;
     } catch (e) {
       console.error(e);

--- a/packages/stencil-library/src/rendererModules/Handle/__tests__/PIDDataType.unit.ts
+++ b/packages/stencil-library/src/rendererModules/Handle/__tests__/PIDDataType.unit.ts
@@ -134,7 +134,7 @@ describe('PIDDataType', () => {
     it('returns cached PIDDataType if already in typeMap', async () => {
       const pid = new PID('21.T11148', 'cached');
       const cached = new PIDDataType(pid, 'Cached', 'Already cached', 'https://cached.com');
-      mockTypeMap.set(pid, cached);
+      mockTypeMap.set(`${pid.prefix}/${pid.suffix}`, cached);
 
       const result = await PIDDataType.resolveDataType(pid);
 
@@ -152,7 +152,7 @@ describe('PIDDataType', () => {
       const result = await PIDDataType.resolveDataType(pid);
 
       expect(result).toBeUndefined();
-      expect(mockUnresolvables.has(pid)).toBe(true);
+      expect(mockUnresolvables.has(`${pid.prefix}/${pid.suffix}`)).toBe(true);
     });
 
     it('resolves a PID with 10320/loc XML containing json and html locations', async () => {
@@ -194,8 +194,8 @@ describe('PIDDataType', () => {
       expect(result.pid).toBe(pid);
 
       // Should be cached in typeMap
-      expect(mockTypeMap.has(pid)).toBe(true);
-      expect(mockTypeMap.get(pid)).toBe(result);
+      expect(mockTypeMap.has(`${pid.prefix}/${pid.suffix}`)).toBe(true);
+      expect(mockTypeMap.get(`${pid.prefix}/${pid.suffix}`)).toBe(result);
     });
 
     it('resolves a PID with only an html location (no json)', async () => {

--- a/packages/stencil-library/src/utils/GitHubRegistryUtil.ts
+++ b/packages/stencil-library/src/utils/GitHubRegistryUtil.ts
@@ -1,0 +1,81 @@
+import { PID } from '../rendererModules/Handle/PID';
+import { PIDDataType } from '../rendererModules/Handle/PIDDataType';
+import { typeMap } from './utils';
+import { cachedFetch } from './DataCache';
+
+interface GitHubApiEntry {
+  name: string;
+  path: string;
+  type: string;
+  download_url?: string;
+}
+
+interface SimpleTypeRegistryEntry {
+  pid: string;
+  name: string;
+  description: string;
+}
+
+export class GitHubRegistryUtil {
+  private static readonly GITHUB_API_BASE = 'https://api.github.com/repos/ThomasJejkal/simple-type-registry/contents/types?recursive=1';
+  private static initialized = false;
+
+  /**
+   * Initializes the simple type registry by fetching all JSON files from the GitHub repository.
+   * Skips files located in 'schemas' subdirectory.
+   */
+  public static async initializeFromGitHub(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    try {
+      const entries = await cachedFetch(this.GITHUB_API_BASE) as GitHubApiEntry[];
+
+      if (!Array.isArray(entries)) {
+        console.warn('GitHub API did not return an array of entries');
+        return;
+      }
+
+      for (const entry of entries) {
+        // Skip files in 'schemas' directory
+        if (entry.path.includes('schemas')) {
+          continue;
+        }
+
+        // Only process JSON files
+        if (entry.type === 'file' && entry.name.endsWith('.json') && entry.download_url) {
+          try {
+            const fileData = await cachedFetch(entry.download_url) as SimpleTypeRegistryEntry;
+
+            if (fileData.pid) {
+              const pid = PID.getPIDFromString(fileData.pid);
+              const dataType = new PIDDataType(
+                pid,
+                fileData.name || '',
+                fileData.description || '',
+                entry.download_url,
+                undefined
+              );
+
+              typeMap.set(pid, dataType);
+            }
+          } catch (error) {
+            console.warn(`Failed to process file ${entry.name}:`, error);
+          }
+        }
+      }
+
+      this.initialized = true;
+    } catch (error) {
+      console.error('Failed to initialize type registry from GitHub:', error);
+    }
+  }
+
+  /**
+   * Resets the initialization state (useful for testing).
+   */
+  public static reset(): void {
+    this.initialized = false;
+  }
+}

--- a/packages/stencil-library/src/utils/GitHubRegistryUtil.ts
+++ b/packages/stencil-library/src/utils/GitHubRegistryUtil.ts
@@ -1,14 +1,8 @@
 import { PID } from '../rendererModules/Handle/PID';
 import { PIDDataType } from '../rendererModules/Handle/PIDDataType';
-import { typeMap } from './utils';
+import { handleMap, typeMap } from './utils';
 import { cachedFetch } from './DataCache';
-
-interface GitHubApiEntry {
-  name: string;
-  path: string;
-  type: string;
-  download_url?: string;
-}
+import { PIDRecord } from '../rendererModules/Handle/PIDRecord';
 
 interface SimpleTypeRegistryEntry {
   pid: string;
@@ -16,66 +10,91 @@ interface SimpleTypeRegistryEntry {
   description: string;
 }
 
+interface TreeEntry {
+  path: string;
+  type: string;
+}
+
 export class GitHubRegistryUtil {
-  private static readonly GITHUB_API_BASE = 'https://api.github.com/repos/ThomasJejkal/simple-type-registry/contents/types?recursive=1';
-  private static initialized = false;
+  private static readonly GITHUB_TREE_API = 'https://api.github.com/repos/ThomasJejkal/simple-type-registry/git/trees/main?recursive=1';
+  private static readonly GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/ThomasJejkal/simple-type-registry/main/types';
+  private static initPromise: Promise<void> | null = null;
 
-  /**
-   * Initializes the simple type registry by fetching all JSON files from the GitHub repository.
-   * Skips files located in 'schemas' subdirectory.
-   */
-  public static async initializeFromGitHub(): Promise<void> {
-    if (this.initialized) {
-      return;
-    }
-
+  private static async doInitialize(): Promise<void> {
     try {
-      const entries = await cachedFetch(this.GITHUB_API_BASE) as GitHubApiEntry[];
+      const treeData = await cachedFetch(this.GITHUB_TREE_API) as { tree: TreeEntry[] };
 
-      if (!Array.isArray(entries)) {
-        console.warn('GitHub API did not return an array of entries');
+      if (!treeData.tree || !Array.isArray(treeData.tree)) {
+        console.warn('GitHub API did not return a valid tree');
         return;
       }
 
-      for (const entry of entries) {
-        // Skip files in 'schemas' directory
-        if (entry.path.includes('schemas')) {
-          continue;
+      const jsonFiles = treeData.tree.filter((entry: TreeEntry) => {
+        if (entry.type !== 'blob') {
+          return false;
         }
+        if (!entry.path.endsWith('.json')) {
+          return false;
+        }
+        if (!entry.path.startsWith('types/')) {
+          return false;
+        }
+        return !entry.path.includes('/schemas/');
+      });
 
-        // Only process JSON files
-        if (entry.type === 'file' && entry.name.endsWith('.json') && entry.download_url) {
-          try {
-            const fileData = await cachedFetch(entry.download_url) as SimpleTypeRegistryEntry;
+      for (const file of jsonFiles) {
+        try {
+          const url = `${this.GITHUB_RAW_BASE}/${file.path.replace('types/', '')}`;
+          const fileData = await cachedFetch(url) as SimpleTypeRegistryEntry;
 
-            if (fileData.pid) {
-              const pid = PID.getPIDFromString(fileData.pid);
-              const dataType = new PIDDataType(
-                pid,
-                fileData.name || '',
-                fileData.description || '',
-                entry.download_url,
-                undefined
-              );
+          if (fileData.pid) {
+            const pid = PID.getPIDFromString(fileData.pid);
+            const dataType = new PIDDataType(
+              pid,
+              fileData.name,
+              fileData.description || '',
+              url,
+              undefined
+            );
 
-              typeMap.set(pid, dataType);
-            }
-          } catch (error) {
-            console.warn(`Failed to process file ${entry.name}:`, error);
+            typeMap.set(pid.toString(), dataType);
+            const timestamp = Date.now();
+            const handleData = [{
+              index: 1,
+              type: dataType,
+              data: { format: 'string', value: '' },
+              ttl: 86400,
+              timestamp
+            }];
+            const pidRecord = new PIDRecord(pid, handleData);
+
+            handleMap.set(pid.toString(), pidRecord);
           }
+        } catch (error) {
+          console.warn(`Failed to process file ${file.path}:`, error);
         }
       }
-
-      this.initialized = true;
     } catch (error) {
       console.error('Failed to initialize type registry from GitHub:', error);
     }
   }
 
   /**
+   * Initializes the simple type registry by fetching all JSON files from the GitHub repository.
+   * Skips files located in 'schemas' subdirectory.
+   * Returns a promise that resolves when initialization is complete.
+   */
+  public static initializeFromGitHub(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.doInitialize();
+    }
+    return this.initPromise;
+  }
+
+  /**
    * Resets the initialization state (useful for testing).
    */
   public static reset(): void {
-    this.initialized = false;
+    this.initPromise = null;
   }
 }

--- a/packages/stencil-library/src/utils/utils.ts
+++ b/packages/stencil-library/src/utils/utils.ts
@@ -1,4 +1,3 @@
-import { PID } from '../rendererModules/Handle/PID';
 import { PIDDataType } from '../rendererModules/Handle/PIDDataType';
 import { PIDRecord } from '../rendererModules/Handle/PIDRecord';
 import { GenericIdentifierType } from './GenericIdentifierType';
@@ -116,18 +115,21 @@ export const renderers: {
 
 /**
  * A map of all PID data types and their PIDs.
- * @type {Map<PID, PIDDataType>}
+ * Uses PID string representation as keys for reliable lookup.
+ * @type {Map<string, PIDDataType>}
  */
-export const typeMap: Map<PID, PIDDataType> = new Map();
+export const typeMap: Map<string, PIDDataType> = new Map();
 
 /**
  * A map of all PIDs and their PIDRecords.
- * @type {Map<PID, PIDRecord>}
+ * Uses PID string representation as keys for reliable lookup.
+ * @type {Map<string, PIDRecord>}
  */
-export const handleMap: Map<PID, PIDRecord> = new Map();
+export const handleMap: Map<string, PIDRecord> = new Map();
 
 /**
  * A set of all PIDs that are not resolvable.
- * @type {Set<PID>}
+ * Uses PID string representation for reliable lookup.
+ * @type {Set<string>}
  */
-export const unresolvables: Set<PID> = new Set();
+export const unresolvables: Set<string> = new Set();

--- a/packages/stencil-library/web-types.json
+++ b/packages/stencil-library/web-types.json
@@ -11,7 +11,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/color-highlight/color-highlight.tsx",
+            "module": "src\\components\\color-highlight\\color-highlight.tsx",
             "symbol": "ColorHighlight"
           },
           "attributes": [
@@ -32,7 +32,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/copy-button/copy-button.tsx",
+            "module": "src\\components\\copy-button\\copy-button.tsx",
             "symbol": "CopyButton"
           },
           "attributes": [
@@ -69,7 +69,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/json-viewer/json-viewer.tsx",
+            "module": "src\\components\\json-viewer\\json-viewer.tsx",
             "symbol": "JsonViewer"
           },
           "attributes": [
@@ -135,7 +135,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/locale-vizualization/locale-visualization.tsx",
+            "module": "src\\components\\locale-vizualization\\locale-visualization.tsx",
             "symbol": "LocaleVisualization"
           },
           "attributes": [
@@ -164,7 +164,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/pid-actions/pid-actions.tsx",
+            "module": "src\\components\\pid-actions\\pid-actions.tsx",
             "symbol": "PidActions"
           },
           "attributes": [
@@ -193,7 +193,7 @@
           "deprecated": false,
           "description": "Component for creating collapsible/expandable content sections\nwith resize capability and cross-browser compatibility",
           "source": {
-            "module": "src/components/pid-collapsible/pid-collapsible.tsx",
+            "module": "src\\components\\pid-collapsible\\pid-collapsible.tsx",
             "symbol": "PidCollapsible"
           },
           "attributes": [
@@ -278,7 +278,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/pid-component/pid-component.tsx",
+            "module": "src\\components\\pid-component\\pid-component.tsx",
             "symbol": "PidComponent"
           },
           "attributes": [
@@ -411,7 +411,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/pid-data-table/pid-data-table.tsx",
+            "module": "src\\components\\pid-data-table\\pid-data-table.tsx",
             "symbol": "PidDataTable"
           },
           "attributes": [
@@ -488,7 +488,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/pid-pagination/pid-pagination.tsx",
+            "module": "src\\components\\pid-pagination\\pid-pagination.tsx",
             "symbol": "PidPagination"
           },
           "attributes": [
@@ -541,7 +541,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src/components/pid-tooltip/pid-tooltip.tsx",
+            "module": "src\\components\\pid-tooltip\\pid-tooltip.tsx",
             "symbol": "PidTooltip"
           },
           "attributes": [

--- a/packages/stencil-library/web-types.json
+++ b/packages/stencil-library/web-types.json
@@ -11,7 +11,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\color-highlight\\color-highlight.tsx",
+            "module": "src/components/color-highlight/color-highlight.tsx",
             "symbol": "ColorHighlight"
           },
           "attributes": [
@@ -32,7 +32,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\copy-button\\copy-button.tsx",
+            "module": "src/components/copy-button/copy-button.tsx",
             "symbol": "CopyButton"
           },
           "attributes": [
@@ -69,7 +69,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\json-viewer\\json-viewer.tsx",
+            "module": "src/components/json-viewer/json-viewer.tsx",
             "symbol": "JsonViewer"
           },
           "attributes": [
@@ -135,7 +135,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\locale-vizualization\\locale-visualization.tsx",
+            "module": "src/components/locale-vizualization/locale-visualization.tsx",
             "symbol": "LocaleVisualization"
           },
           "attributes": [
@@ -164,7 +164,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\pid-actions\\pid-actions.tsx",
+            "module": "src/components/pid-actions/pid-actions.tsx",
             "symbol": "PidActions"
           },
           "attributes": [
@@ -193,7 +193,7 @@
           "deprecated": false,
           "description": "Component for creating collapsible/expandable content sections\nwith resize capability and cross-browser compatibility",
           "source": {
-            "module": "src\\components\\pid-collapsible\\pid-collapsible.tsx",
+            "module": "src/components/pid-collapsible/pid-collapsible.tsx",
             "symbol": "PidCollapsible"
           },
           "attributes": [
@@ -278,7 +278,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\pid-component\\pid-component.tsx",
+            "module": "src/components/pid-component/pid-component.tsx",
             "symbol": "PidComponent"
           },
           "attributes": [
@@ -411,7 +411,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\pid-data-table\\pid-data-table.tsx",
+            "module": "src/components/pid-data-table/pid-data-table.tsx",
             "symbol": "PidDataTable"
           },
           "attributes": [
@@ -488,7 +488,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\pid-pagination\\pid-pagination.tsx",
+            "module": "src/components/pid-pagination/pid-pagination.tsx",
             "symbol": "PidPagination"
           },
           "attributes": [
@@ -541,7 +541,7 @@
           "deprecated": false,
           "description": "",
           "source": {
-            "module": "src\\components\\pid-tooltip\\pid-tooltip.tsx",
+            "module": "src/components/pid-tooltip/pid-tooltip.tsx",
             "symbol": "PidTooltip"
           },
           "attributes": [


### PR DESCRIPTION
This PR implements the support for resolving FAIR DOs created by the current version of FAIR DO MoMEnT, e.g., [21.11152/8a0091ce-792f-4a78-8b6b-e4b58393e809](https://hdl.handle.net/21.11152/8a0091ce-792f-4a78-8b6b-e4b58393e809?noredirect). The reason for the modification is, that such FAIR DOs are not (yet) using DataTypes registered in the official DTR, but custom DataTypes registered in a dedicated [GitHub repository](https://github.com/ThomasJejkal/simple-type-registry).

Changes are the following:

- Introduced GitHubRegistryUtil to load all types from the GitHub repository, transform, and store them in typeMap and handleMap
- Changed typeMap and handleMap to use PID strings as keys instread of objects, as entries added by GitHubRegistryUtil couldn't be found

